### PR TITLE
Fix deadlock in event handler for thumbnail tap

### DIFF
--- a/LensBlurApp/Pages/GalleryPage.xaml.cs
+++ b/LensBlurApp/Pages/GalleryPage.xaml.cs
@@ -104,7 +104,7 @@ namespace LensBlurApp.Pages
             _viewModel = null;
         }
 
-        private void Thumbnail_Tap(object sender, System.Windows.Input.GestureEventArgs e)
+        private async void Thumbnail_Tap(object sender, System.Windows.Input.GestureEventArgs e)
         {
             var image = sender as Image;
             var photo = image.Tag as Photo;
@@ -113,7 +113,7 @@ namespace LensBlurApp.Pages
             {
                 var task = photo.File.OpenReadAsync().AsTask();
 
-                task.Wait();
+                await task;
 
                 Model.OriginalImage = task.Result.AsStream();
                 Model.Saved = false;


### PR DESCRIPTION
Lines 114-116 of LensBlurApp/Pages/GalleryPage.xaml.cs say
var task = photo.File.OpenReadAsync().AsTask();
task.Wait();

The Wait on line 114 will block the UI thread. The thread can proceed
only when the Task returned by OpenReadAsync().AsTask() competes.
However, the continuation completing this task will
be posted to the captured synchronization context from the UI thread,
which is blocked, and will never run. This results in deadlock.
This patch replaces task.Wait() by await task, and marks the event
handler async. Avoiding the blocking wait fixes the deadlock.
